### PR TITLE
add rate limiting to recurring jobs

### DIFF
--- a/recurring.js
+++ b/recurring.js
@@ -16,7 +16,7 @@ Recurring.prototype.scriptdir = __dirname + '/scripts/recurring';
     //config should have {timeout: seconds}
     this.create = function(config, callback) {
         config = JSON.stringify(config);
-        return this.runscript('create', [config], callback);
+        return this.runscript('create', [config, Date.now().toString()], callback);
     };
 
     this.exists = function(callback) {

--- a/scripts/recurring/create.lua
+++ b/scripts/recurring/create.lua
@@ -1,7 +1,8 @@
 --name, config
-local name = ARGV[1];
-local config = cjson.decode(ARGV[2]);
+local name, config, curtime = unpack(ARGV);
+local config = cjson.decode(config);
 
+redis.call('SET', 'recurring.lastcheck:'..name, curtime);
 for key, value in pairs(config) do
     redis.call('HSET', 'recurring.config:'..name, key, value);
 end

--- a/scripts/recurring/get.lua
+++ b/scripts/recurring/get.lua
@@ -2,12 +2,17 @@
 local name, curtime = unpack(ARGV);
 
 local r = redis.call('zrange', 'recurring:'..name, 0, 0, 'WITHSCORES');
+local lastcheck = redis.call('GET', 'recurring.lastcheck:'..name);
+local ratelimit = redis.call('HGET', 'recurring.config:'..name, 'ratelimit');
 if(#r == 2) then
     if(r[2] > curtime) then
         return {"NOTYET", false, r[2]};
+    elseif(tonumber(curtime) < lastcheck + ratelimit) then
+        return {"NOTYET", false, lastcheck + ratelimit};
     else
         local timeout = redis.call('HGET', 'recurring.config:'..name, 'timeout');
         redis.call('ZADD', 'recurring:'..name, curtime + timeout, r[1]);
+        redis.call('SET', 'recurring.lastcheck:'..name, curtime);
         return {false, r[1], r[2]};
     end
 else


### PR DESCRIPTION
Recurring jobs now support a ratelimit config item that will cause the get to return a NOTYET error when requests are made too quickly
